### PR TITLE
Fix build on the Arm Compiler

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -8,7 +8,7 @@ aws-iot-device-sdk-embedded-c/scripts/*
 aws-iot-device-sdk-embedded-c/tests/*
 aws-iot-device-sdk-embedded-c/third_party/*
 aws-iot-device-sdk-embedded-c/libraries/aws/common/test/*
-aws-iot-device-sdk-embedded-c/libraries/aws/defender/test/*
+aws-iot-device-sdk-embedded-c/libraries/aws/defender/*
 aws-iot-device-sdk-embedded-c/libraries/aws/jobs/test/*
 aws-iot-device-sdk-embedded-c/libraries/aws/shadow/test/*
 aws-iot-device-sdk-embedded-c/libraries/standard/common/test/*

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ An example demonstrating the use of this library has been provided as part of th
 1. The "Config header" and the "Platform Types" requirements can be found in the library under [`mbed/include/`](./mbed/include)
 1. The "Platform layer" port can be found under [`mbed/src/`](./mbed/src) . As a minimum, a system clock, mutex, semaphore, network implementation and an optional thread implementation are required. More details on this are provided [here](https://docs.aws.amazon.com/freertos/latest/lib-ref/c-sdk/platform/index.html#platform). The thread implementation is optional and needed for synchronization between threads while using traces for debug messages.
 
+## Note on the IoT Defender service
+
+For now, the [IoT Defender](https://docs.aws.amazon.com/iot/latest/developerguide/device-defender.html) service is disabled in this port library. If you need to enable it for your project:
+
+* Open [.mbedignore](./.mbedignore) and change
+
+   ```diff
+   -aws-iot-device-sdk-embedded-c/libraries/aws/defender/*
+   +aws-iot-device-sdk-embedded-c/libraries/aws/defender/test/*
+   ```
+
+* Implement `IotClock_SleepMs`, `IotSemaphore_TryWait` and `IotMetrics_GetTcpConnections` in your application, as the Defender module depends on them. For their API requirements, search for them in the source code of [aws-iot-device-sdk-embedded-c](https://github.com/aws/aws-iot-device-sdk-embedded-C)
+
 ## Related Links
 
 * [Mbed OS Stats API](https://os.mbed.com/docs/latest/apis/mbed-statistics.html).
@@ -26,3 +39,4 @@ An example demonstrating the use of this library has been provided as part of th
 ### License and contributions
 
 The software is provided under Apache-2.0 license. Contributions to this project are accepted under the same license.
+

--- a/cbor.h
+++ b/cbor.h
@@ -1,0 +1,2 @@
+// The AWS SDK expects cbor.h but https://github.com/ARMmbed/tinycbor has tinycbor.h
+#include "tinycbor.h"

--- a/mbed/src/iot_clock.cpp
+++ b/mbed/src/iot_clock.cpp
@@ -32,7 +32,7 @@ uint64_t IotClock_GetTimeMs(void) {
 
 bool IotClock_GetTimestring(char * pBuffer, size_t bufferSize, size_t * pTimestringLength) {
     auto now = time(NULL);
-    auto length = strftime(pBuffer, bufferSize, "%d %b %Y %H:%M", gmtime(&now));
+    auto length = strftime(pBuffer, bufferSize, "%d %b %Y %H:%M", localtime(&now));
     if (pTimestringLength != NULL) {
         *pTimestringLength = length;
     }

--- a/tinycbor.lib
+++ b/tinycbor.lib
@@ -1,1 +1,1 @@
-https://github.com/intel/tinycbor.git\#755f9ef932f9830a63a712fd2ac971d838b131f1
+https://github.com/ARMmbed/tinycbor.git#6280306360cc76649b063993f1b2e03fcc92d4cc


### PR DESCRIPTION
Part of the fix for https://github.com/ARMmbed/mbed-os-example-aws/issues/3
(Needs  https://github.com/ARMmbed/mbed-os-example-aws/pull/7 too)

This PR addresses two issues that prevent the Arm Compiler from building [mbed-os-example-aws](https://github.com/ARMmbed/mbed-os-example-aws).

### Temporarily disable Defender module

The AWS SDK has a Defender module which requires the porting layer
to implement `IotClock_SleepMs`, `IotSemaphore_TryWait` and
`IotMetrics_GetTcpConnections`. For now we haven't provided those yet
because mbed-os-example-aws doesn't use Defender at the moment.

Users can re-enable Defender by adding the missing implementation. Refer to the updated README.

### Use ARMmbed/tinycbor repository for Arm Compiler compatibility

The upstream https://github.com/intel/tinycbor currently
doesn't compile with the Arm Compiler:

  * Its VERSION file causes `#include <version>` to use
    the wrong header
  * It selects static_assert for C files but the Arm Compiler
    only allows _Static_assert

The fork under ARMmbed has those issues resolved.

Note: Our fork has renamed cbor.h -> tinycbor.h, so we create
cbor.h here to maintain compatibility with the AWS SDK.

### Fix strftime() nullptr dereference with logging

Logging isn't properly enabled until we apply #3. Now with logging enabled, `IotClock_GetTimestring()` crashes because it uses `gmtime()` (which returns `NULL` due to the lack of support by the Arm Compiler's C library) in `strftime()`.

The fix is using `localtime()` instead - it is also what the AWS SDK uses in its POSIX implementation.