### PR TITLE
Created class to eliminate lambda that was causing build issues.

### DIFF
--- a/mbed/src/iot_thread.cpp
+++ b/mbed/src/iot_thread.cpp
@@ -1,4 +1,6 @@
-#include "mbed.h"
+#include "platform/Callback.h"
+#include "rtos/Thread.h"
+
 #include "mbed_trace.h"
 
 #define TRACE_GROUP "AWSPort_Thread"
@@ -7,22 +9,53 @@ extern "C" {
 #include "iot_threads.h"
 }
 
+/**
+ * Detached thread with context and arguments
+ *
+ * @note This class should only be created dynamically! It calls `delete this`
+ */
+class AWSDetachedThread
+{
+public:
+
+    AWSDetachedThread(IotThreadRoutine_t routine, void * arg,
+            int32_t priority, size_t stack_size) : _routine(routine),
+            _arg(arg),
+            _thread(osPriorityLow,
+                   (stack_size == 0)? MBED_CONF_RTOS_THREAD_STACK_SIZE : stack_size,
+                    nullptr, "detachable thread") {
+    }
+
+    void start(void) {
+        _thread.start(mbed::callback(this, &AWSDetachedThread::thread_main));
+    }
+
+protected:
+
+    /**
+     * Main for this AWSDetachedThread
+     */
+    void thread_main(void) {
+        tr_debug("entering detachable thread");
+        _routine(_arg);
+        tr_debug("exiting detatchable thread");
+        delete this;
+    }
+
+protected:
+
+    IotThreadRoutine_t _routine;
+    void * _arg;
+
+    rtos::Thread _thread;
+};
+
 bool Iot_CreateDetachedThread( IotThreadRoutine_t threadRoutine,
                                void * pArgument,
                                int32_t priority,
                                size_t stackSize ) {
-    auto thread = new Thread {
-        osPriorityLow,
-        (stackSize==0)? MBED_CONF_RTOS_THREAD_STACK_SIZE : stackSize,
-        nullptr,
-        "detachable thread"
-    };
-    thread->start([=] {
-        tr_debug("entering detachable thread");
-        threadRoutine(pArgument);
-        tr_debug("exiting detatchable thread");
-        delete thread;
-    });
+    auto thread = new AWSDetachedThread(threadRoutine, pArgument, priority, stackSize);
+    thread->start();
 
     return true;
 }


### PR DESCRIPTION
I created a new class, `AWSDetachedThread`, that captures the argument and routine context given by the AWS layer of the application. This is to avoid problems with starting a thread using a callback created with a lambda expression.

I have used lambdas to create callbacks before with Mbed-OS but haven't seen this kind of error before:

```
[ERROR] ./mbed-aws-client/mbed/src/iot_thread.cpp: In function 'bool Iot_CreateDetachedThread(IotThreadRoutine_t, void*, int32_t, size_t)':
./mbed-aws-client/mbed/src/iot_thread.cpp:25:6: error: no matching function for call to 'rtos::Thread::start(Iot_CreateDetachedThread(IotThreadRoutine_t, void*, int32_t, size_t)::<lambda()>)'
   25 |     });
      |      ^
In file included from ./mbed-os/rtos/rtos.h:28,
                 from ./mbed-os/mbed.h:22,
                 from ./mbed-aws-client/mbed/src/iot_thread.cpp:1:
./mbed-os/rtos/Thread.h:264:14: note: candidate: 'osStatus rtos::Thread::start(mbed::Callback<void()>)'
  264 |     osStatus start(mbed::Callback<void()> task);
      |              ^~~~~
./mbed-os/rtos/Thread.h:264:43: note:   no known conversion for argument 1 from 'Iot_CreateDetachedThread(IotThreadRoutine_t, void*, int32_t, size_t)::<lambda()>' to 'mbed::Callback<void()>'
  264 |     osStatus start(mbed::Callback<void()> task);
      |                    ~~~~~~~~~~~~~~~~~~~~~~~^~~~
./mbed-os/rtos/Thread.h:279:14: note: candidate: 'template<class T, class M> osStatus rtos::Thread::start(T*, M)'
  279 |     osStatus start(T *obj, M method)
      |              ^~~~~
./mbed-os/rtos/Thread.h:279:14: note:   template argument deduction/substitution failed:
./mbed-aws-client/mbed/src/iot_thread.cpp:25:6: note:   mismatched types 'T*' and 'Iot_CreateDetachedThread(IotThreadRoutine_t, void*, int32_t, size_t)::<lambda()>'
   25 |     });
      |      ^

[mbed] ERROR: "/home/gdbeckstein/python-mbed/bin/python" returned error.
       Code: 1
       Path: "/home/gdbeckstein/Documents/embeddedplanet/aws-updates/mbed-os-example-aws"
```
I am building with mbed-os 5.15.4 (default for this example I think?) and it was failing to compile with the above error. I was not able to tweak the lambda declaration (using `mbed::callback`, `mbed::Callback<void(void)>`, or any other more explicit declaration) to compile so I implemented the patch in this PR.